### PR TITLE
[S] Sort pg dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@repositive/event-store",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,19 +27,16 @@
     "ava": "0.25.0",
     "ava-ts": "0.24.6",
     "nyc": "^12.0.2",
-    "pg": "7.4.3",
     "sinon": "^6.1.4",
     "ts-node": "7.0.0",
     "tslint": "5.11.0",
     "typescript": "3.1.0-dev.20180721",
     "uuid": "^3.3.2"
   },
-  "peerDependencies": {
-    "pg": "7.4.x"
-  },
   "dependencies": {
     "@repositive/iris": "^1.0.0-alpha.8",
     "config": "^2.0.1",
+    "pg": "7.4.3",
     "funfix": "7.0.1",
     "ramda": "0.25.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repositive/event-store",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Event store implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This is an issue if the service that is using the event store is not using pg or maybe even when it's using a different version.

This came up when importing this module in Hermes for the Type of Events.