### PR TITLE
[F] return None if createAggregate fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,7 @@ export async function newEventStore<Q>(
         return aggregatedResult;
       } catch (error) {
         logger.error('errorOnReduction', error);
-        return Promise.reject(error);
+        return None;
       }
     }
 


### PR DESCRIPTION
Currently if you try to aggregate with an ID that doesn't exist, the `createAggregate` function fails with a [rejected Promise.](https://github.com/repositive/event-store/blob/98adedd39b75d4e89ad4fb8c1d81f5697e6ae387/src/index.ts#L193-L195)

This should actually return `Option<None>` so that mapping over the result can trigger a `.getOrElseL()` and return the desired error.