### PR TITLE
[F] TA-116 Add helper to create complete events

### DIFF
--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -2,92 +2,92 @@ import { test } from 'ava';
 import { id } from './test-helpers';
 import { createEvent, createContext, EventData, EventContext, Event } from '.';
 
-test('creates an event with default fields filled', t => {
-	const evt = createEvent(
-		{ event_type: 'Type', event_namespace: 'ns', data: { foo: 'bar' } as any },
-		() => id,
-		() => '2018-01-02 03-04-05'
-	);
+test('creates an event with default fields filled', (t) => {
+  const evt = createEvent(
+    { event_type: 'Type', event_namespace: 'ns', data: { foo: 'bar' } as any },
+    () => id,
+    () => '2018-01-02 03-04-05',
+  );
 
-	const expected = {
-		id,
-		data: {
-			type: 'ns.Type',
-			event_type: 'Type',
-			event_namespace: 'ns',
-			foo: 'bar'
-		},
-		context: {
-			subject: {},
-			time: '2018-01-02 03-04-05'
-		}
-	};
+  const expected = {
+    id,
+    data: {
+      type: 'ns.Type',
+      event_type: 'Type',
+      event_namespace: 'ns',
+      foo: 'bar',
+    },
+    context: {
+      subject: {},
+      time: '2018-01-02 03-04-05',
+    },
+  };
 
-	t.deepEqual(evt, expected);
+  t.deepEqual(evt, expected);
 });
 
-test('creates an event with a given context', t => {
-	const evt = createEvent(
-		{
-			event_type: 'Type',
-			event_namespace: 'ns',
-			data: { foo: 'bar' } as any,
-			context: { subject: { bar: 'baz' }, time: new Date().toISOString() }
-		},
-		() => id,
-		() => '2018-01-02 03-04-05'
-	);
+test('creates an event with a given context', (t) => {
+  const evt = createEvent(
+    {
+      event_type: 'Type',
+      event_namespace: 'ns',
+      data: { foo: 'bar' } as any,
+      context: { subject: { bar: 'baz' }, time: new Date().toISOString() },
+    },
+    () => id,
+    () => '2018-01-02 03-04-05',
+  );
 
-	const expected = {
-		id,
-		data: {
-			type: 'ns.Type',
-			event_type: 'Type',
-			event_namespace: 'ns',
-			foo: 'bar'
-		},
-		context: {
-			subject: { bar: 'baz' },
-			time: '2018-01-02 03-04-05'
-		}
-	};
+  const expected = {
+    id,
+    data: {
+      type: 'ns.Type',
+      event_type: 'Type',
+      event_namespace: 'ns',
+      foo: 'bar',
+    },
+    context: {
+      subject: { bar: 'baz' },
+      time: '2018-01-02 03-04-05',
+    },
+  };
 
-	t.deepEqual(evt, expected);
+  t.deepEqual(evt, expected);
 });
 
-test('creates a context with subject and no action', t => {
-	const evt = createEvent(
-		{
-			event_type: 'Type',
-			event_namespace: 'ns',
-			data: { foo: 'bar' } as any,
-			context: createContext({ bar: 'baz' })
-		},
-		() => id,
-		() => '2018-01-02 03-04-05'
-	);
+test('creates a context with subject and no action', (t) => {
+  const evt = createEvent(
+    {
+      event_type: 'Type',
+      event_namespace: 'ns',
+      data: { foo: 'bar' } as any,
+      context: createContext({ bar: 'baz' }),
+    },
+    () => id,
+    () => '2018-01-02 03-04-05',
+  );
 
-	t.is(evt.context.action, undefined);
-	t.deepEqual(evt.context.subject, { bar: 'baz' });
+  t.is(evt.context.action, undefined);
+  t.deepEqual(evt.context.subject, { bar: 'baz' });
 });
 
-test('creates a context with subject and an action', t => {
-	const evt = createEvent(
-		{
-			event_type: 'Type',
-			event_namespace: 'ns',
-			data: { foo: 'bar' } as any,
-			context: createContext({ bar: 'baz' }, 'someRandomAction', () => '2018-01-02 03-04-05')
-		},
-		() => id,
-		() => '2018-01-02 03-04-05'
-	);
+test('creates a context with subject and an action', (t) => {
+  const evt = createEvent(
+    {
+      event_type: 'Type',
+      event_namespace: 'ns',
+      data: { foo: 'bar' } as any,
+      context: createContext({ bar: 'baz' }, 'someRandomAction', () => '2018-01-02 03-04-05'),
+    },
+    () => id,
+    () => '2018-01-02 03-04-05',
+  );
 
-	const expected = {
-		action: 'someRandomAction',
-		subject: { bar: 'baz' },
-		time: '2018-01-02 03-04-05'
-	};
+  const expected = {
+    action: 'someRandomAction',
+    subject: { bar: 'baz' },
+    time: '2018-01-02 03-04-05',
+  };
 
-	t.deepEqual(evt.context, expected);
+  t.deepEqual(evt.context, expected);
 });

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -3,11 +3,7 @@ import { id } from './test-helpers';
 import { createEvent, createContext, EventData, EventContext, Event } from '.';
 
 test('creates an event with default fields filled', (t) => {
-  const evt = createEvent(
-    { event_type: 'Type', event_namespace: 'ns', data: { foo: 'bar' } as any },
-    () => id,
-    () => '2018-01-02 03-04-05',
-  );
+  const evt = createEvent('ns', 'Type', { foo: 'bar' } as any);
 
   const expected = {
     id,
@@ -23,19 +19,19 @@ test('creates an event with default fields filled', (t) => {
     },
   };
 
-  t.deepEqual(evt, expected);
+  t.deepEqual(evt.data, expected.data);
+  t.deepEqual(evt.context.subject, expected.context.subject);
+  t.is(typeof evt.context.time, 'string');
+  t.true(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(evt.id));
 });
 
 test('creates an event with a given context', (t) => {
   const evt = createEvent(
-    {
-      event_type: 'Type',
-      event_namespace: 'ns',
-      data: { foo: 'bar' } as any,
-      context: { subject: { bar: 'baz' }, time: new Date().toISOString() },
-    },
+    'ns',
+    'Type',
+    { foo: 'bar' } as any,
+    { subject: { bar: 'baz' }, time: '2018-01-02 03-04-05' },
     () => id,
-    () => '2018-01-02 03-04-05',
   );
 
   const expected = {
@@ -57,14 +53,11 @@ test('creates an event with a given context', (t) => {
 
 test('creates a context with subject and no action', (t) => {
   const evt = createEvent(
-    {
-      event_type: 'Type',
-      event_namespace: 'ns',
-      data: { foo: 'bar' } as any,
-      context: createContext({ bar: 'baz' }),
-    },
+    'ns',
+    'Type',
+    { foo: 'bar' } as any,
+    createContext({ bar: 'baz' }),
     () => id,
-    () => '2018-01-02 03-04-05',
   );
 
   t.is(evt.context.action, undefined);
@@ -73,14 +66,11 @@ test('creates a context with subject and no action', (t) => {
 
 test('creates a context with subject and an action', (t) => {
   const evt = createEvent(
-    {
-      event_type: 'Type',
-      event_namespace: 'ns',
-      data: { foo: 'bar' } as any,
-      context: createContext({ bar: 'baz' }, 'someRandomAction', () => '2018-01-02 03-04-05'),
-    },
+    'ns',
+    'Type',
+    { foo: 'bar' } as any,
+    createContext({ bar: 'baz' }, 'someRandomAction', () => '2018-01-02 03-04-05'),
     () => id,
-    () => '2018-01-02 03-04-05',
   );
 
   const expected = {

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,0 +1,93 @@
+import { test } from 'ava';
+import { id } from './test-helpers';
+import { createEvent, createContext, EventData, EventContext, Event } from '.';
+
+test('creates an event with default fields filled', t => {
+	const evt = createEvent(
+		{ event_type: 'Type', event_namespace: 'ns', data: { foo: 'bar' } as any },
+		() => id,
+		() => '2018-01-02 03-04-05'
+	);
+
+	const expected = {
+		id,
+		data: {
+			type: 'ns.Type',
+			event_type: 'Type',
+			event_namespace: 'ns',
+			foo: 'bar'
+		},
+		context: {
+			subject: {},
+			time: '2018-01-02 03-04-05'
+		}
+	};
+
+	t.deepEqual(evt, expected);
+});
+
+test('creates an event with a given context', t => {
+	const evt = createEvent(
+		{
+			event_type: 'Type',
+			event_namespace: 'ns',
+			data: { foo: 'bar' } as any,
+			context: { subject: { bar: 'baz' }, time: new Date().toISOString() }
+		},
+		() => id,
+		() => '2018-01-02 03-04-05'
+	);
+
+	const expected = {
+		id,
+		data: {
+			type: 'ns.Type',
+			event_type: 'Type',
+			event_namespace: 'ns',
+			foo: 'bar'
+		},
+		context: {
+			subject: { bar: 'baz' },
+			time: '2018-01-02 03-04-05'
+		}
+	};
+
+	t.deepEqual(evt, expected);
+});
+
+test('creates a context with subject and no action', t => {
+	const evt = createEvent(
+		{
+			event_type: 'Type',
+			event_namespace: 'ns',
+			data: { foo: 'bar' } as any,
+			context: createContext({ bar: 'baz' })
+		},
+		() => id,
+		() => '2018-01-02 03-04-05'
+	);
+
+	t.is(evt.context.action, undefined);
+	t.deepEqual(evt.context.subject, { bar: 'baz' });
+});
+
+test('creates a context with subject and an action', t => {
+	const evt = createEvent(
+		{
+			event_type: 'Type',
+			event_namespace: 'ns',
+			data: { foo: 'bar' } as any,
+			context: createContext({ bar: 'baz' }, 'someRandomAction', () => '2018-01-02 03-04-05')
+		},
+		() => id,
+		() => '2018-01-02 03-04-05'
+	);
+
+	const expected = {
+		action: 'someRandomAction',
+		subject: { bar: 'baz' },
+		time: '2018-01-02 03-04-05'
+	};
+
+	t.deepEqual(evt.context, expected);
+});

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -3,7 +3,7 @@ import { id } from './test-helpers';
 import { createEvent, createContext, EventData, EventContext, Event } from '.';
 
 test('creates an event with default fields filled', (t) => {
-  const evt = createEvent('ns', 'Type', { foo: 'bar' } as any);
+  const evt = createEvent('ns', 'Type', { foo: 'bar' });
 
   const expected = {
     id,
@@ -29,7 +29,7 @@ test('creates an event with a given context', (t) => {
   const evt = createEvent(
     'ns',
     'Type',
-    { foo: 'bar' } as any,
+    { foo: 'bar' },
     { subject: { bar: 'baz' }, time: '2018-01-02 03-04-05' },
     () => id,
   );
@@ -55,7 +55,7 @@ test('creates a context with subject and no action', (t) => {
   const evt = createEvent(
     'ns',
     'Type',
-    { foo: 'bar' } as any,
+    { foo: 'bar' },
     createContext({ bar: 'baz' }),
     () => id,
   );
@@ -68,7 +68,7 @@ test('creates a context with subject and an action', (t) => {
   const evt = createEvent(
     'ns',
     'Type',
-    { foo: 'bar' } as any,
+    { foo: 'bar' },
     createContext({ bar: 'baz' }, 'someRandomAction', () => '2018-01-02 03-04-05'),
     () => id,
   );

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,19 +9,11 @@ function defaultContext(): EventContext<{}> {
 }
 
 export function createEvent<D extends EventData>(
-  {
-    event_type,
-    event_namespace,
-    data,
-    context = defaultContext(),
-  }: {
-    event_type: string;
-    event_namespace: string;
-    data: D;
-    context?: EventContext<any>;
-  },
+  event_namespace: string,
+  event_type: string,
+  data: D,
+  context: EventContext<any> = defaultContext(),
   _uuid: () => string = v4,
-  _time: () => string = () => new Date().toISOString(),
 ): Event<EventData, EventContext<any>> {
   const d = {
     ...(data as object),
@@ -30,15 +22,9 @@ export function createEvent<D extends EventData>(
     event_namespace,
   };
 
-  // Allow overriding of time value for testing purposes
-  const c: EventContext<any> = {
-    ...context,
-    time: _time(),
-  };
-
   return {
     data: d,
-    context: c,
+    context,
     id: _uuid(),
   };
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,55 +2,55 @@ import { EventData, EventContext, Event } from '.';
 import { v4 } from 'uuid';
 
 function defaultContext(): EventContext<{}> {
-	return {
-		subject: {},
-		time: new Date().toISOString()
-	};
+  return {
+    subject: {},
+    time: new Date().toISOString(),
+  };
 }
 
 export function createEvent<D extends EventData>(
-	{
-		event_type,
-		event_namespace,
-		data,
-		context = defaultContext()
-	}: {
-		event_type: string;
-		event_namespace: string;
-		data: D;
-		context?: EventContext<any>;
-	},
-	_uuid: () => string = v4,
-	_time: () => string = () => new Date().toISOString()
+  {
+    event_type,
+    event_namespace,
+    data,
+    context = defaultContext(),
+  }: {
+    event_type: string;
+    event_namespace: string;
+    data: D;
+    context?: EventContext<any>;
+  },
+  _uuid: () => string = v4,
+  _time: () => string = () => new Date().toISOString(),
 ): Event<EventData, EventContext<any>> {
-	const d = {
-		...(data as object),
-		type: `${event_namespace}.${event_type}`,
-		event_type,
-		event_namespace
-	};
+  const d = {
+    ...(data as object),
+    type: `${event_namespace}.${event_type}`,
+    event_type,
+    event_namespace,
+  };
 
-	// Allow overriding of time value for testing purposes
-	const c: EventContext<any> = {
-		...context,
-		time: _time()
-	};
+  // Allow overriding of time value for testing purposes
+  const c: EventContext<any> = {
+    ...context,
+    time: _time(),
+  };
 
-	return {
-		data: d,
-		context: c,
-		id: _uuid()
-	};
+  return {
+    data: d,
+    context: c,
+    id: _uuid(),
+  };
 }
 
 export function createContext(
-	subject: object,
-	action?: string,
-	_time: () => string = () => new Date().toISOString()
+  subject: object,
+  action?: string,
+  _time: () => string = () => new Date().toISOString(),
 ): EventContext<any> {
-	return {
-		action,
-		subject,
-		time: _time()
-	};
+  return {
+    action,
+    subject,
+    time: _time(),
+  };
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,56 @@
+import { EventData, EventContext, Event } from '.';
+import { v4 } from 'uuid';
+
+function defaultContext(): EventContext<{}> {
+	return {
+		subject: {},
+		time: new Date().toISOString()
+	};
+}
+
+export function createEvent<D extends EventData>(
+	{
+		event_type,
+		event_namespace,
+		data,
+		context = defaultContext()
+	}: {
+		event_type: string;
+		event_namespace: string;
+		data: D;
+		context?: EventContext<any>;
+	},
+	_uuid: () => string = v4,
+	_time: () => string = () => new Date().toISOString()
+): Event<EventData, EventContext<any>> {
+	const d = {
+		...(data as object),
+		type: `${event_namespace}.${event_type}`,
+		event_type,
+		event_namespace
+	};
+
+	// Allow overriding of time value for testing purposes
+	const c: EventContext<any> = {
+		...context,
+		time: _time()
+	};
+
+	return {
+		data: d,
+		context: c,
+		id: _uuid()
+	};
+}
+
+export function createContext(
+	subject: object,
+	action?: string,
+	_time: () => string = () => new Date().toISOString()
+): EventContext<any> {
+	return {
+		action,
+		subject,
+		time: _time()
+	};
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,15 +8,15 @@ function defaultContext(): EventContext<{}> {
   };
 }
 
-export function createEvent<D extends EventData>(
+export function createEvent(
   event_namespace: string,
   event_type: string,
-  data: D,
+  data: object,
   context: EventContext<any> = defaultContext(),
   _uuid: () => string = v4,
 ): Event<EventData, EventContext<any>> {
   const d = {
-    ...(data as object),
+    ...data,
     type: `${event_namespace}.${event_type}`,
     event_type,
     event_namespace,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as R from 'ramda';
 import { Future, Option, None, Either, Left, Right } from 'funfix';
 import { createHash } from 'crypto';
 import { v4 } from 'uuid';
+export { createEvent, createContext } from './helpers';
 
 export * from './adapters';
 import {createDumbCacheAdapter, createDumbEmitterAdapter} from './adapters';


### PR DESCRIPTION
It's error prone and difficult (particularly without documentation) to create the correct event payload. This PR adds helper function(s) to make correct event creation easier.

Events can now be created like this:

```typescript
const evt = createEvent('namespace', 'Type', { event: 'data here' });
```

Or with a context:

```typescript
const evt = createEvent('namespace', 'Type', { event: 'data here' }, createContext({ subject: 'info here' }));
```