### PR TITLE
[B] Fix event replay requested looking for itself

### DIFF
--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -94,7 +94,7 @@ export function createFakeIterator(result: any[]) {
       } else {
         return { value: result[idx - 1], done: false };
       }
-    }
+    },
   };
 }
 
@@ -114,7 +114,7 @@ export async function getFakeStoreAdapter({
     };
 
   const storeAdapter = {
-    read: (query: any, time: any, ...args: any[]) => {
+    read: (readQuery: any, time: any, ...args: any[]) => {
       let idx = 0;
       const result = readStub(...args);
 
@@ -131,15 +131,15 @@ export async function getFakeStoreAdapter({
           } else {
             return { value: result[idx - 1], done: false };
           }
-        }
+        },
       };
     },
     write: (event: Event<EventData, EventContext<any>>): Promise<any> => {
       return writer(event).then(() => Right(undefined));
     },
     lastEventOf: (): any => ({}),
-    readEventSince: readSinceStub
+    readEventSince: readSinceStub,
   };
 
-  return storeAdapter
+  return storeAdapter;
 }

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,5 +1,7 @@
 import { Client, Pool, QueryConfig, QueryResult } from 'pg';
 import { stub } from 'sinon';
+import { Event, EventData, EventContext } from '.';
+import { Right } from 'funfix';
 
 export const cafebabe = "cafebabe-cafe-babe-cafe-babecafebabe";
 export const id = "d00dd00d-d00d-d00d-d00d-d00dd00dd00d";
@@ -78,4 +80,66 @@ export function truncateAll(pool: any = getDbConnection()): Promise<any> {
 // For integration tests
 export async function query(q: string, pool: any = getDbConnection()): Promise<any> {
   return (await pool.query(q)).rows;
+}
+
+export function createFakeIterator(result: any[]) {
+  let idx = 0;
+
+  return {
+    next: (): any => {
+      idx++;
+
+      if (idx > result.length) {
+        return { done: true };
+      } else {
+        return { value: result[idx - 1], done: false };
+      }
+    }
+  };
+}
+
+export async function getFakeStoreAdapter({
+  readStub,
+  readSinceStub,
+  saveStub,
+}: {
+  readStub?: any,
+  readSinceStub: any,
+  saveStub?: (evt: any) => Promise<undefined>,
+}): Promise<any> {
+  const writer =
+    saveStub ||
+    function(evt: any): Promise<undefined> {
+      return Promise.resolve(undefined);
+    };
+
+  const storeAdapter = {
+    read: (query: any, time: any, ...args: any[]) => {
+      let idx = 0;
+      const result = readStub(...args);
+
+      if (!(result instanceof Array)) {
+        throw new Error('Read stub must return an array. Are you resolving a promise instead?');
+      }
+
+      return {
+        next: (): any => {
+          idx++;
+
+          if (idx > result.length) {
+            return { done: true };
+          } else {
+            return { value: result[idx - 1], done: false };
+          }
+        }
+      };
+    },
+    write: (event: Event<EventData, EventContext<any>>): Promise<any> => {
+      return writer(event).then(() => Right(undefined));
+    },
+    lastEventOf: (): any => ({}),
+    readEventSince: readSinceStub
+  };
+
+  return storeAdapter
 }


### PR DESCRIPTION
Prior to this fix, the `EventReplayRequested` handler was looking for itself in the database, instead of the event it was requesting the replay of. This PR fixes this problem, and adds a unit test to check this behaviour.