### PR TITLE
[B] Strip payload out of Iris messages for event handler

### DIFF
--- a/src/adapters/emitter/amqp.ts
+++ b/src/adapters/emitter/amqp.ts
@@ -38,8 +38,10 @@ export function createAQMPEmitterAdapter(irisOpts: IrisOptions, logger: Logger =
   }
 
   function subscribe(pattern: string, handler: EventHandler<any>) {
+    const _handler = wrapHandler(handler);
+
     iris.map((i) => {
-      i.register({pattern, handler});
+      i.register({pattern, handler: _handler});
     });
     subscriptions.set(pattern, handler);
   }


### PR DESCRIPTION
Prior to this PR, event handlers had a full Iris message passed to them, i.e. a handler would receive `{ payload: /* actual event here */, ... }`. This is wrong; the event should be moved out of the `payload` and passed just as a raw event.