### PR TITLE
[B] Do not handle user code errors

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -298,7 +298,7 @@ test('listen calls handler if event doesnt exist and saves after its execution',
   const subscribe = spy();
 
   const exists = stub().resolves(false);
-  const saveStub = stub();
+  const saveStub = stub().resolves();
   const store = await getFakeStoreAdapter({exists, saveStub});
 
   const emitter = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,16 +252,12 @@ export async function newEventStore<Q>(
     const pattern = [event_namespace, event_type].join('.');
 
     const _handler = async (event: Event<any, any>) => {
-      try {
-        const exists = await store.exists(event.id);
-        if (!exists) {
-          const result = await handler(event);
-          await result.map(() => {
-            return store.write(event);
-          }).get();
-        }
-      } catch (err) {
-        logger.error(err);
+      const exists = await store.exists(event.id);
+      if (!exists) {
+        const result = await handler(event);
+        await result.map(() => {
+          return store.write(event);
+        }).getOrElse(Promise.resolve());
       }
     };
 


### PR DESCRIPTION
Do not handle user errors. By doing this we mask potential problems in the user code and leads to a lot of pain while doing debugging.

The user must handle potential errors on the handler and return `Left` if a problem occurs.