### PR TITLE
Modularise event-store and clean unnused code

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,6 +1,42 @@
+import {Option, Either} from 'funfix';
+import {Event, EventData, EventContext} from '..';
 
 export * from './cache/postgres';
 export * from './cache/dumb';
 export * from './emitter/amqp';
 export * from './emitter/dumb';
 export * from './store/postgres';
+
+export interface CacheEntry<T> {
+  time?: string; // ISO String
+  data: T;
+}
+
+export interface CacheAdapter {
+  get<T>(id: string): Promise<Option<CacheEntry<T>>>;
+  set<T extends CacheEntry<any>>(id: string, obj: T): Promise<void>;
+}
+
+export type EmitterHandler<T extends Event<EventData, EventContext<any>>> = (
+  event: T,
+) => Promise<void>;
+
+export interface EmitterAdapter {
+  emit(event: Event<any, any>): Promise<void>;
+  subscribe<T extends Event<EventData, EventContext<any>>>(
+    name: string,
+    handler: EmitterHandler<T>,
+  ): void;
+}
+
+export class DuplicateError extends Error {}
+export interface StoreAdapter<Q> {
+  read(query: Q, since: Option<string>, ...args: any[]): AsyncIterator<Event<EventData, EventContext<any>>>;
+  write(event: Event<EventData, EventContext<any>>): Promise<Either<DuplicateError, void>>;
+  lastEventOf<E extends Event<any, any>>(eventType: string): Promise<Option<E>>;
+  exists(id: string): Promise<boolean>;
+  readEventSince(
+    eventTYpe: string,
+    since?: Option<string>,
+  ): AsyncIterator<Event<EventData, EventContext<any>>>;
+}

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -1,0 +1,234 @@
+import {
+  Event,
+  EventData,
+  EventContext,
+  StoreAdapter,
+  DuplicateError,
+  CacheAdapter,
+  EmitterAdapter,
+  Logger,
+  createDumbCacheAdapter,
+  createDumbEmitterAdapter,
+  Aggregator,
+} from '.';
+import { None, Some, Option, Either } from 'funfix';
+import { v4 } from 'uuid';
+import { createHash } from 'crypto';
+
+export type Aggregate<A extends any[], T> = (...args: A) => Promise<Option<T>>;
+export type ValidateF<E extends Event<any, any>> = (o: any) => o is E;
+export type ExecuteF<T, E extends Event<any, any>> = (acc: Option<T>, ev: E) => Promise<Option<T>>;
+export type AggregateMatch<A, T extends Event<any, any>> = [ValidateF<T>, ExecuteF<A, T>];
+export type AggregateMatches<T> = Array<AggregateMatch<T, any>>;
+
+export type EventHandler<Q, T extends Event<EventData, EventContext<any>>> = (
+  event: T,
+  store: EventStore<Q>,
+) => Promise<Either<undefined, undefined>>;
+
+export interface EventStoreOptions {
+  cache?: CacheAdapter;
+  emitter?: EmitterAdapter;
+  logger?: Logger;
+}
+
+export class EventStore<Q> {
+  private store: StoreAdapter<Q>;
+  private cache: CacheAdapter;
+  private emitter: EmitterAdapter;
+  private logger: Logger;
+
+  constructor(store_adapter: StoreAdapter<Q>, options: EventStoreOptions = {}) {
+    this.store = store_adapter;
+    this.cache = options.cache || createDumbCacheAdapter();
+    this.emitter = options.emitter || createDumbEmitterAdapter();
+    this.logger = options.logger || console;
+
+    this.emitter.subscribe(
+      '_eventstore.EventStoreReplayRequested',
+      createEventReplayHandler({store: this.store, emitter: this.emitter}),
+    );
+  }
+
+  public async save(event: Event<EventData, EventContext<any>>): Promise<void> {
+    await this.store.write(event).then((result) => {
+      return result
+        .map(() => {
+          // If there are no errors saving, emit the event
+          return this.emitter.emit(event);
+        })
+        .getOrElseL(() => {
+          return result
+            .swap()
+            .map((error) => {
+              if (error instanceof DuplicateError) {
+                return Promise.resolve();
+              }
+              return Promise.reject(error);
+            })
+            .get();
+        });
+    });
+  }
+
+  public createAggregate<A extends any[], T>(
+    aggregateName: string,
+    query: Q,
+    matches: AggregateMatches<T>,
+  ): Aggregate<A, T> {
+    const _impl = async (...args: A): Promise<Option<T>> => {
+      const start = Date.now();
+
+      const id = createHash('sha256')
+        .update(aggregateName + JSON.stringify(query) + JSON.stringify(args))
+        .digest('hex');
+
+      const latestSnapshot = await this.cache.get<T>(id);
+
+      this.logger.trace('cacheSnapshot', latestSnapshot);
+      const results = this.store.read(
+        query,
+        latestSnapshot.flatMap((snapshot) => Option.of(snapshot.time)),
+        ...args,
+      );
+
+      const aggregatedAt = new Date();
+      const aggregator = composeAggregator(matches);
+
+      const aggregatedResult = await reduce<Event<EventData, EventContext<any>>, Option<T>>(
+        results,
+        latestSnapshot.map((snapshot) => snapshot.data),
+        aggregator,
+      );
+
+      this.logger.trace('aggregatedResult', aggregatedResult);
+
+      await aggregatedResult.map((result) => {
+        const snapshotHash = latestSnapshot
+          .map((snapshot) => {
+            return createHash('sha256')
+              .update(JSON.stringify(snapshot.data))
+              .digest('hex');
+          })
+          .getOrElse('');
+
+        const toCacheHash = createHash('sha256')
+          .update(JSON.stringify(result))
+          .digest('hex');
+        if (snapshotHash !== toCacheHash) {
+          this.logger.trace('save to cache', result);
+          return this.cache.set(id, { data: result, time: aggregatedAt.toISOString() });
+        }
+      });
+
+      this.logger.trace('aggregateLatency', {
+        query,
+        args,
+        query_time: aggregatedAt.getTime() - start,
+        aggregate_time: Date.now() - aggregatedAt.getTime(),
+        total_time: Date.now() - start,
+      });
+
+      return aggregatedResult;
+    };
+
+    return _impl;
+  }
+
+  public async listen(event_namespace: string, event_type: string, handler: EventHandler<Q, any>): Promise<void> {
+    const pattern = [event_namespace, event_type].join('.');
+
+    const _handler = async (event: Event<any, any>) => {
+      const exists = await this.store.exists(event.id);
+      if (!exists) {
+        const result = await handler(event, this);
+        await result.map(() => {
+          return this.store.write(event);
+        }).getOrElse(Promise.resolve());
+      }
+    };
+
+    this.emitter.subscribe(pattern, _handler);
+
+    const last = await this.store.lastEventOf(pattern);
+
+    this.emitter.emit({
+      id: v4(),
+      data: {
+        type: '_eventstore.EventReplayRequested',
+        event_type: 'EventReplayRequested',
+        event_namespace: '_eventstore',
+        requested_event_namespace: event_namespace,
+        requested_event_type: event_type,
+        since: last.map((l) => l.context.time).getOrElse(new Date(0).toISOString()),
+      },
+      context: {
+        actor: {},
+        time: new Date().toISOString(),
+      },
+    });
+
+    // tes
+  }
+}
+
+export interface EventReplayRequested extends EventData {
+  type: '_eventstore.EventReplayRequested';
+  event_namespace: '_eventstore';
+  event_type: 'EventReplayRequested';
+  requested_event_type: string;
+  requested_event_namespace: string;
+  since: string; // ISO String
+}
+
+export async function reduce<I, O>(
+  iter: AsyncIterator<I>,
+  acc: O,
+  f: (acc: O, next: I) => Promise<O>,
+): Promise<O> {
+  let _acc = acc;
+  while (true) {
+    const _next = await iter.next();
+    if (_next.done) {
+      return _acc;
+    } else {
+      _acc = await f(_acc, _next.value);
+    }
+  }
+}
+
+/**
+ *  Compose a list of maching functions into an aggregator
+ *
+ */
+export function composeAggregator<T>(matches: AggregateMatches<T>): Aggregator<T> {
+  return async (acc: Option<T>, event: Event<EventData, any>) => {
+    return matches.reduce((matchAcc, [validate, execute]) => {
+      if (validate(event)) {
+        return execute(matchAcc, event);
+      }
+      return matchAcc;
+    }, acc);
+  };
+}
+
+export function createEventReplayHandler({
+  store,
+  emitter,
+}: {
+  store: StoreAdapter<any>;
+  emitter: EmitterAdapter;
+}) {
+  return async function handleEventReplay(event: Event<EventReplayRequested, EventContext<any>>) {
+    const events = store.readEventSince(
+      [event.data.requested_event_namespace, event.data.requested_event_type].join('.'),
+      Option.of(event.data.since),
+    );
+
+    // Emit all events;
+    reduce(events, None, async (acc, e) => {
+      await emitter.emit(e);
+      return None;
+    });
+  };
+}

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -152,7 +152,7 @@ export class EventStore<Q> {
 
     const last = await this.store.lastEventOf(pattern);
 
-    this.emitter.emit({
+    await this.emitter.emit({
       id: v4(),
       data: {
         type: '_eventstore.EventReplayRequested',
@@ -168,7 +168,6 @@ export class EventStore<Q> {
       },
     });
 
-    // tes
   }
 }
 

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'ava';
 import { id } from './test-helpers';
-import { createEvent, createContext, EventData, EventContext, Event } from '.';
+import { createEvent, createContext, EventData, EventContext, Event, isEvent } from '.';
 
 test('creates an event with default fields filled', (t) => {
   const evt = createEvent('ns', 'Type', { foo: 'bar' });
@@ -80,4 +80,10 @@ test('creates a context with subject and an action', (t) => {
   };
 
   t.deepEqual(evt.context, expected);
+});
+
+test('createEvent passes is Event', (t) => {
+  const ev = createEvent('ns', 'Type', {});
+
+  t.truthy(isEvent()(ev));
 });

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -85,5 +85,5 @@ test('creates a context with subject and an action', (t) => {
 test('createEvent passes is Event', (t) => {
   const ev = createEvent('ns', 'Type', {});
 
-  t.truthy(isEvent()(ev));
+  t.truthy(isEvent((o: any): o is any => !!o)(ev));
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -41,13 +41,24 @@ export function createContext(
   };
 }
 
+export function isEventData<D extends EventData>(o: any, is?: (o: any) => o is D): o is D {
+  const _is = is || ((_: any) => true);
+  return o && typeof o.event_namespace === 'string' && typeof o.event_type === 'string' && _is(o);
+}
+
+export function isEventContext<S, C extends EventContext<S>>(o: any, is?: (o: any) => o is C): o is C {
+  const _is = is || ((_: any) => true);
+  return o && typeof o.time === 'string' && _is(o);
+}
+
 export function isEvent<D extends EventData, C extends EventContext<any>>(
-  isData: (o: any) => o is D = (o: any): o is any => true,
-  isContext: (o: any) => o is C = (o: any): o is any => true,
+  isData?: (o: any) => o is D,
+  isContext?: (o: any) => o is C,
 ): (o: any) => o is Event<D, C> {
   return function(o: any): o is Event<D, C> {
-    return (
-      o && typeof o.id === 'string' && o.data && isData(o.data) && o.context && isContext(o.context)
-    );
+    return o &&
+    typeof o.id === 'string' &&
+    o.data && isEventData(o.data, isData) &&
+    o.context && isEventContext(o.context, isContext);
   };
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -52,7 +52,7 @@ export function isEventContext<S, C extends EventContext<S>>(o: any, is?: (o: an
 }
 
 export function isEvent<D extends EventData, C extends EventContext<any>>(
-  isData?: (o: any) => o is D,
+  isData: (o: any) => o is D,
   isContext?: (o: any) => o is C,
 ): (o: any) => o is Event<D, C> {
   return function(o: any): o is Event<D, C> {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -40,3 +40,14 @@ export function createContext(
     time: _time(),
   };
 }
+
+export function isEvent<D extends EventData, C extends EventContext<any>>(
+  isData: (o: any) => o is D = (o: any): o is any => true,
+  isContext: (o: any) => o is C = (o: any): o is any => true,
+): (o: any) => o is Event<D, C> {
+  return function(o: any): o is Event<D, C> {
+    return (
+      o && typeof o.id === 'string' && o.data && isData(o.data) && o.context && isContext(o.context)
+    );
+  };
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,16 +37,6 @@ function toAsyncIter<T>(input: T[]): AsyncIterator<T> {
   };
 }
 
-function newEvent(data: EventData) {
-  return {
-    id,
-    data,
-    context: {
-      time: new Date().toISOString(),
-    },
-  };
-}
-
 test('Test composeAggregator one match', async (t) => {
   const validate: any = stub();
   validate.returns(true);
@@ -56,7 +46,7 @@ test('Test composeAggregator one match', async (t) => {
 
   const aggregator = composeAggregator(matches);
   t.deepEqual(typeof aggregator, 'function');
-  t.deepEqual(await aggregator(None, newEvent({ type: 'test' })), Some('test'));
+  t.deepEqual(await aggregator(None, createEvent('test', 'test', {})), Some('test'));
 });
 
 test('Test composeAggregator no matches', async (t) => {
@@ -64,7 +54,7 @@ test('Test composeAggregator no matches', async (t) => {
 
   const aggregator = composeAggregator(matches);
   t.deepEqual(typeof aggregator, 'function');
-  t.deepEqual(await aggregator(None, newEvent({ type: 'test' })), None);
+  t.deepEqual(await aggregator(None, createEvent('test', 'test', {})), None);
 });
 
 test('Test composeAggregator one no matching match', async (t) => {
@@ -76,7 +66,7 @@ test('Test composeAggregator one no matching match', async (t) => {
 
   const aggregator = composeAggregator(matches);
   t.deepEqual(typeof aggregator, 'function');
-  t.deepEqual(await aggregator(None, newEvent({ type: 'test' })), None);
+  t.deepEqual(await aggregator(None, createEvent('test', 'test', {})), None);
 });
 
 test('Iter reducer', async (t) => {
@@ -152,7 +142,7 @@ test('save emits if everything is fine', async (t) => {
 
   const es = await newEventStore(store, { logger, emitter });
 
-  await es.save({ id: '', data: { type: 'test' }, context: { time: '', subject: {} } });
+  await es.save(createEvent('test', 'test', {}));
 
   t.deepEqual(writeStub.callCount, 1);
 
@@ -172,7 +162,7 @@ test('save does not emit on errors', async (t) => {
   const es = await newEventStore(store, { logger, emitter });
 
   try {
-    await es.save({ id: '', data: { type: 'test' }, context: { time: '', subject: {} } });
+    await es.save(createEvent('test', 'test', {}));
     t.fail('On write errors save should reject');
   } catch (err) {
     if (err instanceof Error) {
@@ -197,7 +187,7 @@ test('save does not emit on duplicates', async (t) => {
 
   const es = await newEventStore(store, { logger, emitter });
 
-  await es.save({ id: '', data: { type: 'test' }, context: { time: '', subject: {} } });
+  await es.save(createEvent('test', 'test', {}));
   t.deepEqual(writeStub.callCount, 1);
   t.deepEqual(emitStub.callCount, 0);
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -46,7 +46,7 @@ test('Test composeAggregator one match', async (t) => {
 
   const aggregator = composeAggregator(matches);
   t.deepEqual(typeof aggregator, 'function');
-  t.deepEqual(await aggregator(None, createEvent('test', 'test', {})), Some('test'));
+  t.deepEqual(await aggregator(None, createEvent('test_namespace', 'EventTestType', {})), Some('test'));
 });
 
 test('Test composeAggregator no matches', async (t) => {
@@ -54,7 +54,7 @@ test('Test composeAggregator no matches', async (t) => {
 
   const aggregator = composeAggregator(matches);
   t.deepEqual(typeof aggregator, 'function');
-  t.deepEqual(await aggregator(None, createEvent('test', 'test', {})), None);
+  t.deepEqual(await aggregator(None, createEvent('test_namespace', 'EventTestType', {})), None);
 });
 
 test('Test composeAggregator one no matching match', async (t) => {
@@ -66,7 +66,7 @@ test('Test composeAggregator one no matching match', async (t) => {
 
   const aggregator = composeAggregator(matches);
   t.deepEqual(typeof aggregator, 'function');
-  t.deepEqual(await aggregator(None, createEvent('test', 'test', {})), None);
+  t.deepEqual(await aggregator(None, createEvent('test_namespace', 'EventTestType', {})), None);
 });
 
 test('Iter reducer', async (t) => {
@@ -142,7 +142,7 @@ test('save emits if everything is fine', async (t) => {
 
   const es = await newEventStore(store, { logger, emitter });
 
-  await es.save(createEvent('test', 'test', {}));
+  await es.save(createEvent('test_namespace', 'EventTestType', {}));
 
   t.deepEqual(writeStub.callCount, 1);
 
@@ -162,7 +162,7 @@ test('save does not emit on errors', async (t) => {
   const es = await newEventStore(store, { logger, emitter });
 
   try {
-    await es.save(createEvent('test', 'test', {}));
+    await es.save(createEvent('test_namespace', 'EventTestType', {}));
     t.fail('On write errors save should reject');
   } catch (err) {
     if (err instanceof Error) {
@@ -187,7 +187,7 @@ test('save does not emit on duplicates', async (t) => {
 
   const es = await newEventStore(store, { logger, emitter });
 
-  await es.save(createEvent('test', 'test', {}));
+  await es.save(createEvent('test_namespace', 'EventTestType', {}));
   t.deepEqual(writeStub.callCount, 1);
   t.deepEqual(emitStub.callCount, 0);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,5 +40,12 @@ export async function newEventStore<Q>(
   store: StoreAdapter<Q>,
   _options?: EventStoreOptions,
 ): Promise<EventStore<Q>> {
+  const options = _options || {};
+  const { logger = console } = options;
+  logger.warn(`
+    DEPRECATED WARNING!\n
+    The newEventStore function is deprecated and will be remove in a future version of the store.\n
+    Use the EventStore class instead.
+  `);
   return new EventStore(store, _options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,8 +43,8 @@ export async function newEventStore<Q>(
   const options = _options || {};
   const { logger = console } = options;
   logger.warn(`
-    DEPRECATED WARNING!\n
-    The newEventStore function is deprecated and will be remove in a future version of the store.\n
+    DEPRECATED WARNING!
+    The newEventStore function is deprecated and will be remove in a future version of the store.
     Use the EventStore class instead.
   `);
   return new EventStore(store, _options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,106 +1,19 @@
 import { Pool } from 'pg';
 import * as R from 'ramda';
+import { StoreAdapter } from './adapters';
 import { Future, Option, None, Either, Left, Right } from 'funfix';
-import { createHash } from 'crypto';
-import { v4 } from 'uuid';
-export { createEvent, createContext } from './helpers';
-
+import { EventStore, EventStoreOptions } from './event-store';
+export { isEvent, createEvent, createContext } from './helpers';
+export * from './event-store';
 export * from './adapters';
 import { createDumbCacheAdapter, createDumbEmitterAdapter } from './adapters';
 
-export async function reduce<I, O>(
-  iter: AsyncIterator<I>,
-  acc: O,
-  f: (acc: O, next: I) => Promise<O>,
-): Promise<O> {
-  let _acc = acc;
-  while (true) {
-    const _next = await iter.next();
-    if (_next.done) {
-      return _acc;
-    } else {
-      _acc = await f(_acc, _next.value);
-    }
-  }
-}
-
 export type Aggregator<T> = (acc: Option<T>, event: Event<EventData, any>) => Promise<Option<T>>;
-
-/**
- *  Compose a list of maching functions into an aggregator
- *
- */
-export function composeAggregator<T>(matches: AggregateMatches<T>): Aggregator<T> {
-  return async (acc: Option<T>, event: Event<EventData, any>) => {
-    return matches.reduce((matchAcc, [validate, execute]) => {
-      if (validate(event)) {
-        return execute(matchAcc, event);
-      }
-      return matchAcc;
-    }, acc);
-  };
-}
-
-export function isEvent<D extends EventData, C extends EventContext<any>>(
-  isData: (o: any) => o is D = (o: any): o is any => true,
-  isContext: (o: any) => o is C = (o: any): o is any => true,
-): (o: any) => o is Event<D, C> {
-  return function(o: any): o is Event<D, C> {
-    return (
-      o && typeof o.id === 'string' && o.data && isData(o.data) && o.context && isContext(o.context)
-    );
-  };
-}
-
-export interface EventReplayRequested extends EventData {
-  type: '_eventstore.EventReplayRequested';
-  event_namespace: '_eventstore';
-  event_type: 'EventReplayRequested';
-  requested_event_type: string;
-  requested_event_namespace: string;
-  since: string; // ISO String
-}
-
-export class DuplicateError extends Error {}
-export interface StoreAdapter<Q> {
-  read(query: Q, since: Option<string>, ...args: any[]): AsyncIterator<Event<EventData, EventContext<any>>>;
-  write(event: Event<EventData, EventContext<any>>): Promise<Either<DuplicateError, void>>;
-  lastEventOf<E extends Event<any, any>>(eventType: string): Promise<Option<E>>;
-  exists(id: string): Promise<boolean>;
-  readEventSince(
-    eventTYpe: string,
-    since?: Option<string>,
-  ): AsyncIterator<Event<EventData, EventContext<any>>>;
-}
-
-export interface CacheEntry<T> {
-  time?: string; // ISO String
-  data: T;
-}
-
-export interface CacheAdapter {
-  get<T>(id: string): Promise<Option<CacheEntry<T>>>;
-  set<T extends CacheEntry<any>>(id: string, obj: T): Promise<void>;
-}
-
-export type EventHandler<T extends Event<EventData, EventContext<any>>> = (
-  event: T,
-) => Promise<Either<undefined, undefined>>;
-
-export type EmitterHandler<T extends Event<EventData, EventContext<any>>> = (
-  event: T,
-) => Promise<void>;
-
-export interface EmitterAdapter {
-  emit(event: Event<any, any>): Promise<void>;
-  subscribe<T extends Event<EventData, EventContext<any>>>(
-    name: string,
-    handler: EmitterHandler<T>,
-  ): void;
-}
 
 export interface EventData {
   type: string;
+  event_namespace: string;
+  event_type: string;
 }
 
 export interface EventContext<A> {
@@ -115,26 +28,6 @@ export interface Event<D extends EventData, C extends EventContext<any>> {
   context: C;
 }
 
-export type Aggregate<A extends any[], T> = (...args: A) => Promise<Option<T>>;
-export type ValidateF<E extends Event<any, any>> = (o: any) => o is E;
-export type ExecuteF<T, E extends Event<any, any>> = (acc: Option<T>, ev: E) => Promise<Option<T>>;
-export type AggregateMatch<A, T extends Event<any, any>> = [ValidateF<T>, ExecuteF<A, T>];
-export type AggregateMatches<T> = Array<AggregateMatch<T, any>>;
-
-export interface EventStore<Q> {
-  save(event: Event<EventData, EventContext<any>>): Promise<void>;
-  createAggregate<A extends any[], T>(
-    aggregateName: string,
-    query: Q,
-    matches: AggregateMatches<T>,
-  ): Aggregate<A, T>;
-  listen<T extends string>(
-    event_namespace: string,
-    event_type: string,
-    handler: EventHandler<Event<{ type: T }, any>>,
-  ): void;
-}
-
 export interface Logger {
   trace(...args: any[]): void;
   debug(...args: any[]): void;
@@ -143,174 +36,9 @@ export interface Logger {
   error(...args: any[]): void;
 }
 
-export interface EventStoreOptions {
-  cache?: CacheAdapter;
-  emitter?: EmitterAdapter;
-  logger?: Logger;
-}
-
 export async function newEventStore<Q>(
   store: StoreAdapter<Q>,
   _options?: EventStoreOptions,
 ): Promise<EventStore<Q>> {
-  const options = _options || {};
-
-  const {
-    cache = createDumbCacheAdapter(),
-    emitter = createDumbEmitterAdapter(),
-    logger = console,
-  } = options;
-
-  function createAggregate<AQ extends Q, A extends any[], T>(
-    aggregateName: string,
-    query: AQ,
-    matches: AggregateMatches<T>,
-  ): Aggregate<A, T> {
-    async function _impl(...args: A): Promise<Option<T>> {
-      const start = Date.now();
-
-      const id = createHash('sha256')
-        .update(aggregateName + JSON.stringify(query) + JSON.stringify(args))
-        .digest('hex');
-
-      const latestSnapshot = await cache.get<T>(id);
-
-      logger.trace('cacheSnapshot', latestSnapshot);
-      const results = store.read(
-        query,
-        latestSnapshot.flatMap((snapshot) => Option.of(snapshot.time)),
-        ...args,
-      );
-
-      const aggregatedAt = new Date();
-      const aggregator = composeAggregator(matches);
-
-      const aggregatedResult = await reduce<Event<EventData, EventContext<any>>, Option<T>>(
-        results,
-        latestSnapshot.map((snapshot) => snapshot.data),
-        aggregator,
-      );
-
-      logger.trace('aggregatedResult', aggregatedResult);
-
-      await aggregatedResult.map((result) => {
-        const snapshotHash = latestSnapshot
-          .map((snapshot) => {
-            return createHash('sha256')
-              .update(JSON.stringify(snapshot.data))
-              .digest('hex');
-          })
-          .getOrElse('');
-
-        const toCacheHash = createHash('sha256')
-          .update(JSON.stringify(result))
-          .digest('hex');
-        if (snapshotHash !== toCacheHash) {
-          logger.trace('save to cache', result);
-          return cache.set(id, { data: result, time: aggregatedAt.toISOString() });
-        }
-      });
-
-      logger.trace('aggregateLatency', {
-        query,
-        args,
-        query_time: aggregatedAt.getTime() - start,
-        aggregate_time: Date.now() - aggregatedAt.getTime(),
-        total_time: Date.now() - start,
-      });
-
-      return aggregatedResult;
-    }
-
-    return _impl;
-  }
-
-  async function save<T extends string>(
-    event: Event<{ type: T }, EventContext<any>>,
-  ): Promise<void> {
-    await store.write(event).then((result) => {
-      return result
-        .map(() => {
-          // If there are no errors saving, emit the event
-          return emitter.emit(event);
-        })
-        .getOrElseL(() => {
-          return result
-            .swap()
-            .map((error) => {
-              if (error instanceof DuplicateError) {
-                return Promise.resolve();
-              }
-              return Promise.reject(error);
-            })
-            .get();
-        });
-    });
-  }
-
-  async function listen(event_namespace: string, event_type: string, handler: EventHandler<any>) {
-    const pattern = [event_namespace, event_type].join('.');
-
-    const _handler = async (event: Event<any, any>) => {
-      const exists = await store.exists(event.id);
-      if (!exists) {
-        const result = await handler(event);
-        await result.map(() => {
-          return store.write(event);
-        }).getOrElse(Promise.resolve());
-      }
-    };
-
-    emitter.subscribe(pattern, _handler);
-
-    const last = await store.lastEventOf(pattern);
-
-    emitter.emit({
-      id: v4(),
-      data: {
-        type: '_eventstore.EventReplayRequested',
-        event_type: 'EventReplayRequested',
-        event_namespace: '_eventstore',
-        requested_event_namespace: event_namespace,
-        requested_event_type: event_type,
-        since: last.map((l) => l.context.time).getOrElse(new Date(0).toISOString()),
-      },
-      context: {
-        actor: {},
-        time: new Date().toISOString(),
-      },
-    });
-  }
-
-  emitter.subscribe(
-    '_eventstore.EventReplayRequested',
-    createEventReplayHandler({ store, emitter }),
-  );
-
-  return {
-    createAggregate,
-    listen,
-    save,
-  };
-}
-
-export function createEventReplayHandler({
-  store,
-  emitter,
-}: {
-  store: StoreAdapter<any>;
-  emitter: EmitterAdapter;
-}) {
-  return async function handleEventReplay(event: Event<EventReplayRequested, EventContext<any>>) {
-    const events = store.readEventSince(
-      [event.data.requested_event_namespace, event.data.requested_event_type].join('.'),
-      Option.of(event.data.since),
-    );
-
-    // Emit all events;
-    reduce(events, None, async (acc, e) => {
-      await emitter.emit(e);
-      return None;
-    });
-  };
+  return new EventStore(store, _options);
 }

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -12,20 +12,6 @@ const defaultQueryStub = stub()
     totalCount: 0,
   });
 
-export function createEvent(
-  type: string,
-  data: any,
-  context: any = {},
-  time: string = '2018-01-01 01:01:01',
-): any {
-    return {
-      id,
-      data: { ...data, type },
-      context,
-      time,
-    };
-}
-
 export function getFakePool(queryStub: any = defaultQueryStub) {
   const fakePool = {
     async query(q: string | QueryConfig, values?: any[]): Promise<QueryResult> {


### PR DESCRIPTION
This PR does the following:

*Modularisation*
- EventsData must have now `event_type` and `event_namespace`
- Move code from index to new `event-store` module
- Transform current event store implementation from closure based to class based.
- Move type definitions for adapters from index to the adapters module. 
- Remove duplicated code `newEvent` and `createEvent` and move its implementation to the helpers module