### PR TITLE
Transactional EventStore extension

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -29,8 +29,13 @@ export interface EmitterAdapter {
   ): void;
 }
 
+export interface ReadOptions {
+  from?: string;
+  to?: string;
+}
+
 export interface StoreAdapter<Q> {
-  read(query: Q, since: Option<string>, ...args: any[]): AsyncIterator<Event<EventData, EventContext<any>>>;
+  read(query: Q, options: ReadOptions, ...args: any[]): AsyncIterator<Event<EventData, EventContext<any>>>;
   write(data: Event<any, any> | Array<Event<any, any>>): Promise<Either<Error, void>>;
   lastEventOf<E extends Event<any, any>>(eventType: string): Promise<Option<E>>;
   exists(id: string): Promise<boolean>;

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -29,10 +29,9 @@ export interface EmitterAdapter {
   ): void;
 }
 
-export class DuplicateError extends Error {}
 export interface StoreAdapter<Q> {
   read(query: Q, since: Option<string>, ...args: any[]): AsyncIterator<Event<EventData, EventContext<any>>>;
-  write(event: Event<EventData, EventContext<any>>): Promise<Either<DuplicateError, void>>;
+  write(data: Event<any, any> | Array<Event<any, any>>): Promise<Either<Error, void>>;
   lastEventOf<E extends Event<any, any>>(eventType: string): Promise<Option<E>>;
   exists(id: string): Promise<boolean>;
   readEventSince(

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -99,9 +99,10 @@ export class EventStore<Q> {
       const latestSnapshot = await this.cache.get<T>(id);
 
       this.logger.trace('cacheSnapshot', latestSnapshot);
+      const from = latestSnapshot.map((snapshot) => snapshot.time).getOrElse(undefined);
       const results = this.store.read(
         query,
-        latestSnapshot.flatMap((snapshot) => Option.of(snapshot.time)),
+        { from },
         ...args,
       );
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,6 @@
 import test from 'ava';
 import {
   reduce,
-  DuplicateError,
   newEventStore,
   AggregateMatches,
   Event,
@@ -173,23 +172,6 @@ test('save does not emit on errors', async (t) => {
       t.fail('The catch object should be an error');
     }
   }
-});
-
-test('save does not emit on duplicates', async (t) => {
-  const writeStub = stub();
-  writeStub.resolves(Left(new DuplicateError()));
-  const store: any = {
-    write: writeStub,
-  };
-  const emitStub = stub();
-  emitStub.resolves();
-  const emitter: any = { emit: emitStub, subscribe: () => Promise.resolve() };
-
-  const es = await newEventStore(store, { logger, emitter });
-
-  await es.save(createEvent('test_namespace', 'EventTestType', {}));
-  t.deepEqual(writeStub.callCount, 1);
-  t.deepEqual(emitStub.callCount, 0);
 });
 
 test('replay handler reads correct events', async (t) => {


### PR DESCRIPTION
**Status:**
- [x] Adds multiple transactional writes.
- [x] Support time bounded reads.
- [x] Add new `AggregateRoot` type and `prepareAggregate` method to `EventStore` (Simplifies setup of aggregates)
- [ ] Implement Transaction
- [ ] Pass a primmed transaction to event subscription handlers.

**Objective:**
Create a Transaction class with the following fingerprint:

```ts
   interface Transaction {
     /**
     *  Queues one or multiple events for write. If the transaction is closed (commit was executed) this operation throws a  `ClosedTransaction` error.
     */
     save(data: Event | Array<Event>): void;

     /**
     *  Returns an aggregate bound to the events existing to the point this transaction was created.
     *  Appends the queued events to the stream if they overlap in the time range. 
     */
     prepareAggregate(ar: AggregateRoot): Aggregate;

     /**
     *  Writes and emits all the queued events and closes the transaction.
     */
     commit(): Promise<void>;
   }

  interface AggregateRoot<Q> {
    name: string;
    query: Q,
    matches: AggregateMatches;
  }
```