### PR TITLE
[B] Correct replay event name

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -24,7 +24,7 @@ export type EmitterHandler<T extends Event<EventData, EventContext<any>>> = (
 export interface EmitterAdapter {
   emit(event: Event<any, any>): Promise<void>;
   subscribe<T extends Event<EventData, EventContext<any>>>(
-    name: string,
+    name: T["data"]["type"],
     handler: EmitterHandler<T>,
   ): void;
 }

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -45,8 +45,8 @@ export class EventStore<Q> {
     this.emitter = options.emitter || createDumbEmitterAdapter();
     this.logger = options.logger || console;
 
-    this.emitter.subscribe(
-      '_eventstore.EventStoreReplayRequested',
+    this.emitter.subscribe<Event<EventReplayRequested, any>>(
+      '_eventstore.EventReplayRequested',
       createEventReplayHandler({store: this.store, emitter: this.emitter}),
     );
   }


### PR DESCRIPTION
This also adds some type checking to the subscribe method so typos like this ~don't happen~ will happen less in the future.