### PR TITLE
[B] Support old style `type`-fielded events in isEventData

### DIFF
--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -4,17 +4,17 @@ import { createEvent, createContext, EventData, EventContext, Event, isEvent } f
 import { isEventData } from './helpers';
 
 // This test does nothing, but will fail to compile if Typescript finds errors, so should be left in
-test("typechecks createEvent", (t: any) => {
+test('typechecks createEvent', (t: any) => {
   interface TestEvent extends EventData {
-    type: "foobar.Baz";
-    event_namespace: "foobar";
-    event_type: "Baz";
+    type: 'foobar.Baz';
+    event_namespace: 'foobar';
+    event_type: 'Baz';
     foo: string;
     bar: number;
   }
 
-  const evt: Event<TestEvent, any> = createEvent("foobar", "Baz", {
-    foo: "hello",
+  const evt: Event<TestEvent, any> = createEvent('foobar', 'Baz', {
+    foo: 'hello',
     bar: 10,
   });
 
@@ -71,13 +71,7 @@ test('creates an event with a given context', (t: any) => {
 });
 
 test('creates a context with subject and no action', (t: any) => {
-  const evt = createEvent(
-    'ns',
-    'Type',
-    { foo: 'bar' },
-    createContext({ bar: 'baz' }),
-    () => id,
-  );
+  const evt = createEvent('ns', 'Type', { foo: 'bar' }, createContext({ bar: 'baz' }), () => id);
 
   t.is(evt.context.action, undefined);
   t.deepEqual(evt.context.subject, { bar: 'baz' });
@@ -114,17 +108,17 @@ test('isEventData supports new style events', (t: any) => {
       event_namespace: 'some_ns',
       event_type: 'SomeType',
       // New fields should override this
-      type: 'ignoreme.IgnoreMe'
+      type: 'ignoreme.IgnoreMe',
     },
-    context: {}
+    context: {},
   };
 
   t.truthy(
     isEventData(
       fakeEvent.data,
       (data: any): data is any =>
-        data.event_namespace === 'some_ns' && data.event_type === 'SomeType'
-    )
+        data.event_namespace === 'some_ns' && data.event_type === 'SomeType',
+    ),
   );
 });
 
@@ -132,15 +126,12 @@ test('isEventData supports old style events', (t: any) => {
   const fakeEvent: any = {
     id: '...',
     data: {
-      type: 'oldstyle.OldStyle'
+      type: 'oldstyle.OldStyle',
     },
-    context: {}
+    context: {},
   };
 
   t.truthy(
-    isEventData(
-      fakeEvent.data,
-      (data: any): data is any => data.type === 'oldstyle.OldStyle'
-    )
+    isEventData(fakeEvent.data, (data: any): data is any => data.type === 'oldstyle.OldStyle'),
   );
 });

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'ava';
 import { id } from './test-helpers';
 import { createEvent, createContext, EventData, EventContext, Event, isEvent } from '.';
+import { isEventData } from './helpers';
 
 // This test does nothing, but will fail to compile if Typescript finds errors, so should be left in
 test("typechecks createEvent", (t: any) => {
@@ -104,4 +105,42 @@ test('createEvent passes is Event', (t: any) => {
   const ev = createEvent('ns', 'Type', {});
 
   t.truthy(isEvent((o: any): o is any => !!o)(ev));
+});
+
+test('isEventData supports new style events', (t: any) => {
+  const fakeEvent: any = {
+    id: '...',
+    data: {
+      event_namespace: 'some_ns',
+      event_type: 'SomeType',
+      // New fields should override this
+      type: 'ignoreme.IgnoreMe'
+    },
+    context: {}
+  };
+
+  t.truthy(
+    isEventData(
+      fakeEvent.data,
+      (data: any): data is any =>
+        data.event_namespace === 'some_ns' && data.event_type === 'SomeType'
+    )
+  );
+});
+
+test('isEventData supports old style events', (t: any) => {
+  const fakeEvent: any = {
+    id: '...',
+    data: {
+      type: 'oldstyle.OldStyle'
+    },
+    context: {}
+  };
+
+  t.truthy(
+    isEventData(
+      fakeEvent.data,
+      (data: any): data is any => data.type === 'oldstyle.OldStyle'
+    )
+  );
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,9 +11,9 @@ function defaultContext(): EventContext<{}> {
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export function createEvent<T extends EventData>(
-  event_namespace: T["event_namespace"],
-  event_type: T["event_type"],
-  data: Omit<T, "event_namespace" | "event_type" | "type">,
+  event_namespace: T['event_namespace'],
+  event_type: T['event_type'],
+  data: Omit<T, 'event_namespace' | 'event_type' | 'type'>,
   context: EventContext<any> = defaultContext(),
   _uuid: () => string = v4,
 ): Event<T, EventContext<any>> {
@@ -54,7 +54,10 @@ export function isEventData<D extends EventData>(o: any, is?: (o: any) => o is D
   );
 }
 
-export function isEventContext<S, C extends EventContext<S>>(o: any, is?: (o: any) => o is C): o is C {
+export function isEventContext<S, C extends EventContext<S>>(
+  o: any,
+  is?: (o: any) => o is C,
+): o is C {
   const _is = is || ((_: any) => true);
   return o && typeof o.time === 'string' && _is(o);
 }
@@ -64,9 +67,13 @@ export function isEvent<D extends EventData, C extends EventContext<any>>(
   isContext?: (o: any) => o is C,
 ): (o: any) => o is Event<D, C> {
   return function(o: any): o is Event<D, C> {
-    return o &&
-    typeof o.id === 'string' &&
-    o.data && isEventData(o.data, isData) &&
-    o.context && isEventContext(o.context, isContext);
+    return (
+      o &&
+      typeof o.id === 'string' &&
+      o.data &&
+      isEventData(o.data, isData) &&
+      o.context &&
+      isEventContext(o.context, isContext)
+    );
   };
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -46,7 +46,12 @@ export function createContext(
 
 export function isEventData<D extends EventData>(o: any, is?: (o: any) => o is D): o is D {
   const _is = is || ((_: any) => true);
-  return o && typeof o.event_namespace === 'string' && typeof o.event_type === 'string' && _is(o);
+  return (
+    o &&
+    ((typeof o.event_namespace === 'string' && typeof o.event_type === 'string') ||
+      typeof o.type === 'string') &&
+    _is(o)
+  );
 }
 
 export function isEventContext<S, C extends EventContext<S>>(o: any, is?: (o: any) => o is C): o is C {


### PR DESCRIPTION
Some legacy events don't have `event_namespace` and `event_type` fields and instead use the old `type` field. This PR adds support for falling back to `type` in `isEventData` if the two new fields do not exist.

Also runs a format in the last commit. 