### PR TITLE
[S] Typecheck event listener strings

### DIFF
--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -136,7 +136,7 @@ export class EventStore<Q> {
     return _impl;
   }
 
-  public async listen(event_namespace: string, event_type: string, handler: EventHandler<Q, any>): Promise<void> {
+  public async listen<T extends EventData>(event_namespace: T['event_namespace'], event_type: T['event_type'], handler: EventHandler<Q, any>): Promise<void> {
     const pattern = [event_namespace, event_type].join('.');
 
     const _handler = async (event: Event<any, any>) => {

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -136,16 +136,22 @@ export class EventStore<Q> {
     return _impl;
   }
 
-  public async listen<T extends EventData>(event_namespace: T['event_namespace'], event_type: T['event_type'], handler: EventHandler<Q, any>): Promise<void> {
+  public async listen<T extends EventData>(
+    event_namespace: T['event_namespace'],
+    event_type: T['event_type'],
+    handler: EventHandler<Q, any>,
+  ): Promise<void> {
     const pattern = [event_namespace, event_type].join('.');
 
     const _handler = async (event: Event<any, any>) => {
       const exists = await this.store.exists(event.id);
       if (!exists) {
         const result = await handler(event, this);
-        await result.map(() => {
-          return this.store.write(event);
-        }).getOrElse(Promise.resolve());
+        await result
+          .map(() => {
+            return this.store.write(event);
+          })
+          .getOrElse(Promise.resolve());
       }
     };
 
@@ -160,7 +166,6 @@ export class EventStore<Q> {
     });
 
     await this.emitter.emit(replay);
-
   }
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -379,3 +379,25 @@ test('listen does not call handler if event already exists and does not save eve
   t.true(handler.notCalled);
   t.true(saveStub.notCalled);
 });
+
+// Noop test, but will fail to compile if something doesn't work
+test('listen type checks its string arguments', async (t) => {
+  interface DummyEvent extends EventData {
+    event_namespace: 'foo';
+    event_type: 'Bar';
+  }
+
+  const writeStub = stub().resolves(Left(new DuplicateError()));
+  const store: any = {
+    write: writeStub,
+    lastEventOf: () => Promise.resolve(None) as any
+  };
+  const emitStub = stub().resolves();
+  const emitter: any = { emit: emitStub, subscribe: () => Promise.resolve() };
+
+  const es = await newEventStore(store, { logger, emitter });
+
+  es.listen<DummyEvent>('foo', 'Bar', () => Promise.resolve() as any);
+
+  t.pass();
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -390,7 +390,7 @@ test('listen type checks its string arguments', async (t) => {
   const writeStub = stub().resolves(Left(new DuplicateError()));
   const store: any = {
     write: writeStub,
-    lastEventOf: () => Promise.resolve(None) as any
+    lastEventOf: () => Promise.resolve(None) as any,
   };
   const emitStub = stub().resolves();
   const emitter: any = { emit: emitStub, subscribe: () => Promise.resolve() };


### PR DESCRIPTION
Somewhat related to repositive/organisations#201, this PR adds additional checking around the static strings passed to `store.listen()`. Like `createEvent()`, unfortunately these checks are opt in by way of passing a type argument like `store.listen<MyEventDataHere>(/* ... */);`, but this is a good start.