### PR TITLE
[S] Basic release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ postgres_data
 *.swp
 *.lock
 doc
+.gh-pages-tmp

--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ The database is started at `postgres://repositive:repositive@localhost:5433/even
 
 * `yarn doc`
 * Open `doc/index.html` in your favourite browser
+
+## Deploy
+
+```bash
+# (optional) login to NPM
+npm login
+
+# Increment NPM version number
+npm version major|minor|patch
+
+# Publish to NPM
+npm publish
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An implementation of the event sourcing paradigm in Typescript.
 
 ## [Documentation](https://repositive.github.io/event-store/doc)
 
-Start by looking at the [`EventStore`](https://repositive.github.io/event-store/doc/classes/eventstore.html) class.
+Start by looking at the `EventStore` class.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The database is started at `postgres://repositive:repositive@localhost:5433/even
 ## Deploy
 
 ```bash
+# Make sure we're deploying up to date master
+git checkout master && git pull
+
 # (optional) login to NPM
 npm login
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,14 @@
     "testIntegration": "nyc --reporter lcov ava-ts --verbose ./src/integrationsetup.ts ./src/**/*.integration.ts",
     "testDev": "nyc --reporter lcov ava-ts --watch",
     "lint": "tslint --project tsconfig.json",
-    "doc": "typedoc --out doc/local --exclude **/*.test.ts --exclude */*.test.ts --excludePrivate --mode file --name 'Event store dev' src"
+    "doc": "typedoc --out doc/local --exclude **/*.test.ts --exclude */*.test.ts --excludePrivate --mode file --name 'Event store dev' src",
+    "prepack": "npm run compile",
+    "publish": "post-publish.sh"
   },
+  "files": [
+    "dist/**",
+    "README.md"
+  ],
   "bugs": {
     "url": "https://github.com/repositive/event-store/issues"
   },
@@ -51,6 +57,7 @@
     "sinon": "^6.1.4",
     "ts-node": "7.0.0",
     "tslint": "5.11.0",
+    "typedoc": "^0.14.0",
     "typescript": "3.1.0-dev.20180721",
     "uuid": "^3.3.2"
   },
@@ -61,10 +68,6 @@
     "@repositive/iris": "^1.0.0-alpha.8",
     "config": "^2.0.1",
     "funfix": "7.0.1",
-    "ramda": "0.25.0",
-    "typedoc": "^0.14.0"
-  },
-  "scripts": {
-    "publish": "post-publish.sh"
+    "ramda": "0.25.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,10 @@
     "lint": "tslint --project tsconfig.json",
     "doc": "typedoc --out doc/local --exclude **/*.test.ts --exclude */*.test.ts --excludePrivate --mode file --name 'Event store dev' src",
     "prepack": "npm run compile",
-    "publish": "post-publish.sh"
+    "publish": "./post-publish.sh"
   },
   "files": [
-    "dist/**",
-    "README.md"
+    "dist/**"
   ],
   "bugs": {
     "url": "https://github.com/repositive/event-store/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repositive/event-store",
-  "version": "0.0.1",
+  "version": "0.0.2-4",
   "description": "Event store implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
     "funfix": "7.0.1",
     "ramda": "0.25.0",
     "typedoc": "^0.14.0"
+  },
+  "scripts": {
+    "publish": "post-publish.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,12 @@
     "testIntegration": "nyc --reporter lcov ava-ts --verbose ./src/integrationsetup.ts ./src/**/*.integration.ts",
     "testDev": "nyc --reporter lcov ava-ts --watch",
     "lint": "tslint --project tsconfig.json",
-    "doc": "typedoc --out doc --exclude **/*.test.ts --exclude */*.test.ts --excludePrivate --mode file --name 'Event store' src"
+    "doc": "typedoc --out doc/local --exclude **/*.test.ts --exclude */*.test.ts --excludePrivate --mode file --name 'Event store dev' src"
   },
+  "bugs": {
+    "url": "https://github.com/repositive/event-store/issues"
+  },
+  "homepage": "https://repositive.github.io/event-store",
   "ava": {
     "sources": [
       "src/**/*.ts"

--- a/post-publish.sh
+++ b/post-publish.sh
@@ -1,12 +1,26 @@
 #!/bin/sh
 
-# Generate documentation. This script should not be run directly. Instead, run with `npm run doc` or `yarn doc`.
+# Post-publish hook. This script should not be run manually.
+# Debugging can be performed with `PATH="$PATH:$(npm bin)" ./post-publish.sh`
 # Requires `jq`; `apt install -y jq`
 
 set -e
 
 VERSION=$(cat package.json | jq .version -r)
-DOC_OUTPUT="doc/${VERSION}"
+DOC_OUTPUT="./doc/${VERSION}"
+DOC_INDEX="./doc/index.html"
+# Temporary folder to add and upload new docs from
+GH_PAGES_WORKTREE=".gh-pages-tmp"
+
+echo "Build docs for version ${VERSION}"
+
+git worktree remove --force "${GH_PAGES_WORKTREE}" || true
+git worktree add "${GH_PAGES_WORKTREE}" gh-pages
+
+cd "${GH_PAGES_WORKTREE}"
+
+# Create a redirect from /doc to the latest version under /doc/a.b.c
+echo "<meta http-equiv=\"refresh\" content=\"0; url=https://repositive.github.io/event-store/doc/${VERSION}\" />" > "${DOC_INDEX}"
 
 typedoc \
     --out "$DOC_OUTPUT" \
@@ -14,5 +28,19 @@ typedoc \
     --exclude */*.test.ts \
     --excludePrivate \
     --mode file \
-    --name "Event store ${VERSION}"
-    src
+    --name "Event store ${VERSION}" \
+    ./src
+
+echo "Adding generated docs"
+git add -f "${DOC_INDEX}"
+git add -f "${DOC_OUTPUT}"
+echo "Comitting"
+git commit -m "Add documentation for version ${VERSION}" || true
+
+echo "Uploading docs for version ${VERSION} to gh-pages"
+git push origin gh-pages
+
+git worktree remove "${GH_PAGES_WORKTREE}"
+
+echo
+echo "Success"

--- a/post-publish.sh
+++ b/post-publish.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Generate documentation. This script should not be run directly. Instead, run with `npm run doc` or `yarn doc`.
+# Requires `jq`; `apt install -y jq`
+
+set -e
+
+VERSION=$(cat package.json | jq .version -r)
+DOC_OUTPUT="doc/${VERSION}"
+
+typedoc \
+    --out "$DOC_OUTPUT" \
+    --exclude **/*.test.ts \
+    --exclude */*.test.ts \
+    --excludePrivate \
+    --mode file \
+    --name "Event store ${VERSION}"
+    src


### PR DESCRIPTION
Closes #29 

* Uses `npm version major|minor|patch` to increment version number
* Uses `npm publish` to publish package to NPM
* Generates documentation as a post-publish step and uploads to `gh-pages` branch under `/doc/a.b.c/` folder
* Creates redirect from `https://repositive.github.io/event-store/doc` to `https://repositive.github.io/event-store/doc/a.b.c` so latest version is always linked

Post-PR-merge steps:

* Release version 0.1.0 as first "clean" release using this process
* Tell people to replace the Git commit hash in their `package.json`s to use normal version numbers now

It's pretty late so I might've missed something, but it appears to work alright.