### PR TITLE
[S] Strictier listen type

### DIFF
--- a/src/event-store.test.ts
+++ b/src/event-store.test.ts
@@ -1,0 +1,32 @@
+import test from 'ava';
+import { stub } from 'sinon';
+import {EventStore, EventData, Event} from '.';
+
+// Noop test, but will fail to compile if something doesn't work
+test("listen type checks its string arguments", async (t) => {
+
+  interface BarEvent extends EventData {
+    event_namespace: "foo";
+    event_type: "Bar";
+  }
+
+  interface BoomEvent extends EventData {
+    event_namespace: 'foo';
+    event_type: 'Boom';
+  }
+
+  const es: EventStore<any> = {
+    listen: stub().resolves(),
+  } as any;
+
+  es.listen<BarEvent>("foo", "Bar", (event: Event<BarEvent, any>) => Promise.resolve() as any);
+  es.listen("foo", "Bar", (event: Event<BarEvent, any>) => Promise.resolve() as any);
+
+  // @ts-ignore This will blow up without ts-ignore
+  es.listen<FooBar>("foo", "Bar", (event: Event<BoomEvent, any>) => Promise.resolve() as any);
+
+  // @ts-ignore This will blow up without ts-ignore
+  es.listen("foo", "Bar", (event: Event<BoomEvent, any>) => Promise.resolve() as any);
+
+  t.pass();
+});

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -358,7 +358,7 @@ export class EventStore<Q> {
 
   let store = new EventStore(...);
 
-  store.listen<SomeEvent>(
+  store.listen(
       'some_namespace',
       'SomeEvent',
       async (event: Event<SomeEvent, any>, store: EventStore) => {

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -379,7 +379,7 @@ export class EventStore<Q> {
   public async listen<T extends EventData>(
     event_namespace: T["event_namespace"],
     event_type: T["event_type"],
-    handler: EventHandler<Q, any>,
+    handler: EventHandler<Q, Event<T, any>>,
   ): Promise<void> {
     const pattern = [event_namespace, event_type].join(".");
 


### PR DESCRIPTION
- This solves an issue where the event handler could take an argument different than the event the listener was intended to receive. _Check example 1 and 2_
- It also allows us to write listeners in a less verbose way by using typescript type inference to identify the types based on the handler passed to the listener. _Check Example 3_

```ts
interface FooEvent extends EventData {
  event_namespace: 'foo';
  event_type: 'Bar';
}

interface BoomEvent extends EventData {
  event_namespace: 'foo';
  event_type: 'Boom';
}

/*Use your imagination, this is "real ES" instance*/;
const es: EventStore = undefined as any;

// Example 1
// This would compile without the patch
es.listen<FooEvent>("foo", "Bar", (event: Event<BoomEvent, any>) => Right (undefined));
// With this patch it fails, as `FooEvent` != `BoomEvent`
// Argument of type '(event: Event<BoomEvent, any>) => any' is not assignable to parameter ...f property 'event_type' are incompatible.

// Example 2
// This would also compile without the patch
es.listen("foo", "Bar", (event: Event<BoomEvent, any>) => Right (undefined));
// With this patch it fails, as `Bar` != `Boom`
// Argument of type '"Bar"' is not assignable to parameter of type '"Boom"'.      

// Example 3
// Type safe declarations are shorter. This is a valid example
es.listen("foo", "Bar", (event: Event<FooEvent, any>) => Right (undefined));
// Both arguments "foo" and "Bar" are typechecked from `FooEvent' "event_namespace" and "event_type"
```