### PR TITLE
[F] Add option to disable replay requests

### DIFF
--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -262,7 +262,10 @@ export class EventStore<Q> {
         aggregator,
       );
 
-      this.logger.trace({ query, aggregatedResult, time: Date.now() - start }, 'eventStoreAggregatedResult');
+      this.logger.trace(
+        { query, aggregatedResult, time: Date.now() - start },
+        'eventStoreAggregatedResult',
+      );
 
       await aggregatedResult.map((result) => {
         const snapshotHash = latestSnapshot
@@ -285,13 +288,16 @@ export class EventStore<Q> {
         }
       });
 
-      this.logger.trace({
-        query,
-        args,
-        query_time: aggregatedAt.getTime() - start,
-        aggregate_time: Date.now() - aggregatedAt.getTime(),
-        total_time: Date.now() - start,
-      }, 'eventStoreAggregateLatency');
+      this.logger.trace(
+        {
+          query,
+          args,
+          query_time: aggregatedAt.getTime() - start,
+          aggregate_time: Date.now() - aggregatedAt.getTime(),
+          total_time: Date.now() - start,
+        },
+        'eventStoreAggregateLatency',
+      );
 
       return aggregatedResult;
     };
@@ -388,7 +394,8 @@ export class EventStore<Q> {
     handler: EventHandler<Q, Event<T, EventContext<any>>>,
     options?: ListenOptions,
   ): Promise<void> {
-    const { executeHandlerIfEventExists, requestReplay } = {...defaultListenOptions, ...options} || defaultListenOptions;
+    const { executeHandlerIfEventExists, requestReplay } =
+      { ...defaultListenOptions, ...options } || defaultListenOptions;
     const pattern = [event_namespace, event_type].join('.');
 
     const _handler = async (event: Event<any, any>) => {
@@ -443,7 +450,10 @@ export class EventStore<Q> {
       const _next = await events.next();
 
       if (_next.done) {
-        this.logger.debug({ totalEvents: iteration, handledEvents: handled }, 'eventStoreReplayAllComplete');
+        this.logger.debug(
+          { totalEvents: iteration, handledEvents: handled },
+          'eventStoreReplayAllComplete',
+        );
         return;
       } else {
         const event = _next.value;
@@ -458,7 +468,7 @@ export class EventStore<Q> {
             event,
             event_ident,
             handler_type: typeof handler,
-            registered_handlers: [ ...handlers.keys() ],
+            registered_handlers: [...handlers.keys()],
             iteration,
           },
           'replayAllEvent',


### PR DESCRIPTION
Passing the following object as the fourth parameter to `store.listen()` will prevent a replay request from being emitted.

```typescript
{
  requestReplay: false
}
```

Disregard the format noise. Probably useful to look at this PR commit-by-commit.