### PR TITLE
[F] FB-133 Add isEventType function

### DIFF
--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -8,7 +8,7 @@ import {
   Event,
   isEvent,
 } from ".";
-import { isEventData } from "./helpers";
+import { isEventData, isEventType } from "./helpers";
 
 // This test does nothing, but will fail to compile if Typescript finds errors, so should be left in
 test("typechecks createEvent", (t: any) => {
@@ -156,4 +156,30 @@ test("isEventData supports old style events", (t: any) => {
       (data: any): data is any => data.type === "oldstyle.OldStyle",
     ),
   );
+});
+
+test("isEventType checks a complete new event", (t: any) => {
+  const fakeEvent: any = {
+    id: "...",
+    data: {
+      event_namespace: "some_ns",
+      event_type: "SomeType",
+      type: "ignoreme.IgnoreMe",
+    },
+    context: { time: 't' },
+  };
+
+  t.truthy(isEventType('some_ns', 'SomeType')(fakeEvent));
+});
+
+test("isEventType checks a complete old event", (t: any) => {
+  const fakeEvent: any = {
+    id: "...",
+    data: {
+      type: "ignoreme.IgnoreMe",
+    },
+    context: { time: 't' },
+  };
+
+  t.truthy(isEventType('ignoreme', 'IgnoreMe')(fakeEvent));
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -241,6 +241,33 @@ export function isEvent<D extends EventData, C extends EventContext<any>>(
 /**
 Match a complete event object against a given namespace and type
 
+A function is returned which can then be passed to aggregators.
+
+```typescript
+import { isEventType, EventData } from "@repositive/event-store";
+
+interface AccountCreated extends EventData { ... };
+interface AccountUpdated extends EventData { ... };
+
+const isAccountCreated = isEventType<AccountCreated>("accounts", "AccountCreated");
+const isAccountUpdated = isEventType<AccountUpdated>("accounts", "AccountUpdated");
+
+export function createUserByIdAggregate(
+  store: EventStore<PgQuery>
+): Aggregate<[string], User> {
+  return store.createAggregate(
+    "User",
+    {
+      text: `select * from events where data->>'user_id' = $1`,
+    },
+    [
+      [isAccountCreated, onAccountCreated],
+      [isAccountUpdated, onAccountUpdated],
+    ]
+  );
+}
+```
+
 @param ns - The event namespace to use, like `search` or `accounts`
 
 @param ty - The event type to use, like `LoggedIn` or `ImageDeleted`

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -237,3 +237,30 @@ export function isEvent<D extends EventData, C extends EventContext<any>>(
     );
   };
 }
+
+/**
+Match a complete event object against a given namespace and type
+
+@param ns - The event namespace to use, like `search` or `accounts`
+
+@param ty - The event type to use, like `LoggedIn` or `ImageDeleted`
+*/
+export function isEventType<E extends EventData>(
+  ns: string,
+  ty: string,
+): (o: any) => o is Event<E, EventContext<any>> {
+  return function(o: any): o is Event<E, EventContext<any>> {
+    return (
+      o &&
+      typeof o.id === 'string' &&
+      o.data &&
+      isEventData(
+        o.data,
+        (d: any): d is E =>
+          (d.event_namespace === ns && d.event_type === ty) || d.type === `${ns}.${ty}`,
+      ) &&
+      o.context &&
+      isEventContext(o.context, (d: any): d is EventContext<any> => true)
+    );
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as R from "ramda";
 import { StoreAdapter } from "./adapters";
 import { Future, Option, None, Either, Left, Right } from "funfix";
 import { EventStore, EventStoreOptions } from "./event-store";
-export { isEvent, createEvent, createContext } from "./helpers";
+export { isEvent, createEvent, createContext, isEventType } from "./helpers";
 export * from "./event-store";
 export * from "./adapters";
 import { createDumbCacheAdapter, createDumbEmitterAdapter } from "./adapters";


### PR DESCRIPTION
As per the doc comment:

Match a complete event object against a given namespace and type

A function is returned which can then be passed to aggregators.

```typescript
import { isEventType, EventData } from "@repositive/event-store";

interface AccountCreated extends EventData { ... };
interface AccountUpdated extends EventData { ... };

const isAccountCreated = isEventType<AccountCreated>("accounts", "AccountCreated");
const isAccountUpdated = isEventType<AccountUpdated>("accounts", "AccountUpdated");

export function createUserByIdAggregate(
  store: EventStore<PgQuery>
): Aggregate<[string], User> {
  return store.createAggregate(
    "User",
    {
      text: `select * from events where data->>'user_id' = $1`,
    },
    [
      [isAccountCreated, onAccountCreated],
      [isAccountUpdated, onAccountUpdated],
    ]
  );
}
```